### PR TITLE
TOC: Add swipe gesture support on mobile

### DIFF
--- a/src/components/TOC.astro
+++ b/src/components/TOC.astro
@@ -133,6 +133,10 @@
         /** Interval ID for rendering progress bars. */
         private readonly intervalId: number;
 
+        /** Touch start and end positions. */
+        private touchStartX: number = 0;
+        private touchEndX: number = 0;
+
         /**
          * Initializes an IntersectionObserver, sets up debounced rendering of progress bars, and initiates periodic
          * scroll checks.
@@ -219,6 +223,23 @@
             if (closeButton) {
                 closeButton.addEventListener('click', () => this.hideTOC());
             }
+
+            document.addEventListener(
+                'touchstart',
+                (e) => {
+                    this.touchStartX = e.touches[0]?.clientX ?? 0;
+                },
+                { passive: true }
+            );
+
+            document.addEventListener(
+                'touchend',
+                (e) => {
+                    this.touchEndX = e.changedTouches[0]?.clientX ?? 0;
+                    this.handleSwipe();
+                },
+                { passive: true }
+            );
         }
 
         /**
@@ -627,6 +648,24 @@
 
                 if (!isWideScreen) {
                     this.renderProgressBars();
+                }
+            }
+        }
+
+        /** Handles swipe events on mobile devices. */
+        private handleSwipe(): void {
+            const swipeDistance = this.touchEndX - this.touchStartX;
+
+            // Only handle swipes on mobile screens.
+            if (window.innerWidth >= TOC.WIDE_SCREEN_WIDTH) {
+                return;
+            }
+
+            if (Math.abs(swipeDistance) >= TOC.SWIPE_THRESHOLD) {
+                if (swipeDistance > 0) {
+                    this.hideTOC();
+                } else {
+                    this.showTOC();
                 }
             }
         }

--- a/src/config/components.ts
+++ b/src/config/components.ts
@@ -42,7 +42,8 @@ export const COMPONENT_CONFIG = {
         MOUSE_THRESHOLD_INACTIVE: 24,
         MOUSE_THRESHOLD_ACTIVE: 320 + 24, // panel width + safe area for accidental mouse movement
         OBSERVER_MARGIN: '0px 0px -80% 0px',
-        WIDE_SCREEN_WIDTH: 1710
+        WIDE_SCREEN_WIDTH: 1710,
+        SWIPE_THRESHOLD: 50
     } satisfies ITOCConfig
 } as const;
 

--- a/src/types/toc.ts
+++ b/src/types/toc.ts
@@ -71,4 +71,7 @@ export interface ITOCConfig {
 
     /** Width at which TOC is considered wide, used to determine if TOC should be rendered in a separate panel. */
     readonly WIDE_SCREEN_WIDTH: number;
+
+    /** Minimum distance for a swipe. */
+    readonly SWIPE_THRESHOLD: number;
 }


### PR DESCRIPTION
Added swipe gesture support to improve the Table of Contents (TOC) navigation experience on mobile devices. Users can now:
- Swipe left to open the TOC
- Swipe right to close the TOC

## Notes
- The swipe functionality only activates on screens narrower than `TOC.WIDE_SCREEN_WIDTH`

Closes #11 