### PR TITLE
Narrow layout tweaks

### DIFF
--- a/src/components/CodeSwitcher.astro
+++ b/src/components/CodeSwitcher.astro
@@ -10,7 +10,7 @@ const { class: className } = Astro.props;
     <div class="code-switcher-tabs flex justify-center"></div>
 
     <div
-        class="code-switcher-content rounded-2xl border border-ui-border p-4 dark:border-ui-border-dark [&>.code-example>.code-switcher-content>*:last-child]:mb-0"
+        class="code-switcher-content rounded-2xl border border-ui-border p-4 pb-1 dark:border-ui-border-dark [&>.code-example>.code-switcher-content>*:last-child]:mb-0"
     >
         <slot />
     </div>

--- a/src/components/GitHubHeader.astro
+++ b/src/components/GitHubHeader.astro
@@ -6,7 +6,7 @@ interface Props {
 const { repoUrl } = Astro.props;
 ---
 
-<header class="mx-auto mb-6 flex max-w-7xl items-center justify-between">
+<header class="mx-auto mb-6 flex max-w-7xl items-center justify-between md:mx-auto md:max-w-3xl md:px-0">
     <a
         href={repoUrl}
         target="_blank"

--- a/src/components/HeadingLinks.astro
+++ b/src/components/HeadingLinks.astro
@@ -95,7 +95,7 @@
             const anchor: HTMLAnchorElement = document.createElement('a');
 
             anchor.className =
-                'anchor absolute left-1 px-2 rounded-full border-none hover:bg-primary dark:hover:bg-primary-dark ' +
+                'anchor absolute -left-6 px-2 rounded-full border-none hover:bg-primary dark:hover:bg-primary-dark ' +
                 'font-source text-[10pt] hover:text-background dark:hover:text-background-dark select-none no-underline';
             anchor.href = `#${id}`;
             anchor.setAttribute('aria-hidden', 'true');

--- a/src/config/components.ts
+++ b/src/config/components.ts
@@ -42,7 +42,7 @@ export const COMPONENT_CONFIG = {
         MOUSE_THRESHOLD_INACTIVE: 24,
         MOUSE_THRESHOLD_ACTIVE: 320 + 24, // panel width + safe area for accidental mouse movement
         OBSERVER_MARGIN: '0px 0px -80% 0px',
-        WIDE_SCREEN_WIDTH: 1710,
+        WIDE_SCREEN_WIDTH: 1664,
         SWIPE_THRESHOLD: 50
     } satisfies ITOCConfig
 } as const;

--- a/src/styles/mdx-content.css
+++ b/src/styles/mdx-content.css
@@ -84,6 +84,21 @@
         @apply mb-3 leading-[1.35rem] lg:text-base lg:leading-[1.68rem];
     }
 
+    & p,
+    & ol,
+    & ul,
+    & table,
+    & blockquote {
+        @apply md:max-w-3xl md:mx-auto;
+    }
+
+    & h1,
+    & h2,
+    & h3,
+    & h4 {
+        @apply md:max-w-3xl md:mx-auto md:px-0;
+    }
+
     & ul li {
         @apply relative before:absolute before:left-[-1.4em] before:content-['→'];
     }


### PR DESCRIPTION
This PR introduces a new narrow layout based on the request by @mtrunkat in #18. Marek, please try this branch and let me know if it works better for you now.

## Detailed changelog:

- Adjust `CodeSwitcher` component padding by adding `pb-1` to ensure consistent spacing.
- Update `GitHubHeader` component to include responsive styles for medium-sized screens with `md:mx-auto`, `md:max-w-3xl`, and `md:px-0`.
- Modify the anchor positioning in the `HeadingLinks` component by changing the left offset to `-left-6` for better alignment.
- Reduce the `WIDE_SCREEN_WIDTH` in the configuration from `1710` to `1664` for improved responsiveness.
- Apply a maximum width of `3xl` and center alignment on medium-sized screens for elements like paragraphs, lists, tables, and blockquotes.
- Ensure headings (`h1`, `h2`, `h3`, and `h4`) are also centered with appropriate padding adjustments on medium-sized screens.

Fixes #18 

/c @netmilk – can you please try this? There are a couple of highly visible changes.